### PR TITLE
fix typo in comment

### DIFF
--- a/lib/scryptenc/scryptenc.h
+++ b/lib/scryptenc/scryptenc.h
@@ -36,7 +36,7 @@
  * NOTE: This file provides prototypes for routines which encrypt/decrypt data
  * using a key derived from a password by using the scrypt key derivation
  * function.  If you are just trying to "hash" a password for user logins,
- * this is not the code you are looking for.  You want to use the crypt_scrypt
+ * this is not the code you are looking for.  You want to use the crypto_scrypt
  * function directly.
  */
 


### PR DESCRIPTION
The warning comment added in ccb623b6d refers to `crypt_scrypt` instead of `crypto_scrypt`.