### PR TITLE
fclose() infile and outfile

### DIFF
--- a/main.c
+++ b/main.c
@@ -135,6 +135,12 @@ main(int argc, char *argv[])
 	insecure_memzero(passwd, strlen(passwd));
 	free(passwd);
 
+	/* Close any files we opened. */
+	if (infile != stdin)
+		fclose(infile);
+	if (outfile != stdout)
+		fclose(outfile);
+
 	/* If we failed, print the right error message and exit. */
 	if (rc != 0) {
 		switch (rc) {


### PR DESCRIPTION
I hope I'm not missing anything silly here.  I think we want to `fclose()` the files we opened, even if those files are `stdin` and `stdout`.

I considered putting this above the `/* If we failed, print the right error message and exit. */` since closing `stdout` wouldn't harm the `warnp()` and `warn0()` because they print to `stderr`, but then I decided I was was being insufficiently paranoid so it would be better to move the clean-up to the very bottom of `main()`.