### PR TITLE
Revert "autoconf compiler warnings"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,15 +48,16 @@ AC_CHECK_FUNCS([mmap])
 
 AC_SYS_LARGEFILE
 
+# Check whether the user has requested to disable compiler warnings
 AC_MSG_CHECKING([compiler_warnings])
 AC_ARG_ENABLE(compiler_warnings,
- AS_HELP_STRING([--disable-compiler-warnings],
-  [Do not request compiler warnings. @<:@kefault=enabled@:>@]),
- [ac_compiler_warnings=$enableval],
- [ac_compiler_warnings=yes])
+   AS_HELP_STRING([--disable-compiler-warnings],
+       [Do not request compiler warnings. @<:@kefault=enabled@:>@]),
+   [ac_compiler_warnings=$enableval],
+   [ac_compiler_warnings=yes])
 AC_MSG_RESULT([${ac_compiler_warnings}])
 AS_IF([test x${ac_compiler_warnings} = xyes],
- [AX_CFLAGS_WARN_ALL])
+   [AX_CFLAGS_WARN_ALL])
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile])

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,15 @@ AC_CHECK_FUNCS([mmap])
 
 AC_SYS_LARGEFILE
 
-AX_CFLAGS_WARN_ALL
+AC_MSG_CHECKING([compiler_warnings])
+AC_ARG_ENABLE(compiler_warnings,
+ AS_HELP_STRING([--disable-compiler-warnings],
+  [Do not request compiler warnings. @<:@kefault=enabled@:>@]),
+ [ac_compiler_warnings=$enableval],
+ [ac_compiler_warnings=yes])
+AC_MSG_RESULT([${ac_compiler_warnings}])
+AS_IF([test x${ac_compiler_warnings} = xyes],
+ [AX_CFLAGS_WARN_ALL])
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
This reverts commit 5d232cf882e985fbb4d037cb3ad8cae8f986640c.

The AX_FLAGS_WARN_ALL macro isn't in Ubuntu 14.04, it isn't included in
scrypt, and since it's GPLv3, I'm not certain we want to distribute it.
(it's not source code, but is "part of the build system" sufficiently separate
from the "derivative work" question?  I'd need to spend a while looking into
this before I'd want to form an opinion one way or the other)

I suggest we disable this for now (to avoid people seeing

    ../configure: line 5050: AX_CFLAGS_WARN_ALL: command not found

when attempting to configure scrypt), and potentially re-enable it if/when the
legal question (and the technical question of how to include it, if we go that
route) is resolved.