### PR TITLE
Updated configure.ac to check for openssl/aes.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,11 @@ AC_CHECK_MEMBERS([struct sysinfo.totalram, struct sysinfo.mem_unit], [], [],
 # to work.
 AC_CHECK_HEADERS([sys/param.h])
 
+# Check if we have <openssl/aes.h>, to fix the make failing when configure 
+# passes.
+AC_CHECK_HEADERS([openssl/aes.h],,
+  [AC_MSG_ERROR([Unable to find the openssl/aes.h header])])
+
 # Check for <sys/sysctl.h>.  If it exists and it defines HW_USERMEM
 # and/or HW_MEMSIZE, we'll try using those as memory limits.
 AC_CHECK_HEADERS([sys/sysctl.h])


### PR DESCRIPTION
Forced configure to fail if it cannot find openssl/aes.h on the system.
Without this, the make fails.

Prior to this patch, make can fail (after a successful configure) with an error such as this: 
![image](https://cloud.githubusercontent.com/assets/13771080/11660361/777c8272-9d92-11e5-8de1-16054864c7b1.png)

Post patch configure fails like this:
![image](https://cloud.githubusercontent.com/assets/13771080/11660380/8c678e52-9d92-11e5-83ac-143a61a44986.png)

A successful configure post patch:
![image](https://cloud.githubusercontent.com/assets/13771080/11660390/944182d6-9d92-11e5-9bb5-7ec16e0ee5ec.png)
