### PR TITLE
Fixed typo in configure.ac re: compiler warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,7 @@ AC_SYS_LARGEFILE
 AC_MSG_CHECKING([compiler_warnings])
 AC_ARG_ENABLE(compiler_warnings,
    AS_HELP_STRING([--disable-compiler-warnings],
-       [Do not request compiler warnings. @<:@kefault=enabled@:>@]),
+       [Do not request compiler warnings. @<:@default=enabled@:>@]),
    [ac_compiler_warnings=$enableval],
    [ac_compiler_warnings=yes])
 AC_MSG_RESULT([${ac_compiler_warnings}])


### PR DESCRIPTION
Minor typo in the most recent PR (https://github.com/Tarsnap/scrypt/pull/23)