### PR TITLE
Provide -P option to read password from stdin

### DIFF
--- a/libcperciva/util/readpass.c
+++ b/libcperciva/util/readpass.c
@@ -196,6 +196,8 @@ err1:
 	insecure_memzero(passbuf, MAXPASSLEN);
 	insecure_memzero(confpassbuf, MAXPASSLEN);
 
+	resetsigs(savedsa);
+
 	/* Failure! */
 	return (-1);
 }

--- a/libcperciva/util/readpass.c
+++ b/libcperciva/util/readpass.c
@@ -38,6 +38,15 @@ handle(int sig)
 	gotsig[sig] = 1;
 }
 
+static void
+warnp_read(FILE *readfrom)
+{
+	if (feof(readfrom))
+		fprintf(stderr, "EOF reading password\n");
+	else
+		warnp("Cannot read password");
+}
+
 /**
  * readpass(passwd, prompt, confirmprompt, devtty)
  * If ${devtty} is non-zero, read a password from /dev/tty if possible; if
@@ -104,7 +113,7 @@ retry:
 
 	/* Read the password. */
 	if (fgets(passbuf, MAXPASSLEN, readfrom) == NULL) {
-		warnp("Cannot read password");
+		warnp_read(readfrom);
 		goto err3;
 	}
 
@@ -113,7 +122,7 @@ retry:
 		if (usingtty)
 			fprintf(stderr, "%s: ", confirmprompt);
 		if (fgets(confpassbuf, MAXPASSLEN, readfrom) == NULL) {
-			warnp("Cannot read password");
+			warnp_read(readfrom);
 			goto err3;
 		}
 		if (strcmp(passbuf, confpassbuf)) {

--- a/libcperciva/util/readpass.c
+++ b/libcperciva/util/readpass.c
@@ -155,8 +155,6 @@ retry:
 	if (usingtty)
 		tcsetattr(fileno(readfrom), TCSANOW, &term_old);
 
-	resetsigs(savedsa);
-
 	/* Close /dev/tty if we opened it. */
 	if (readfrom != stdin)
 		fclose(readfrom);
@@ -179,6 +177,8 @@ retry:
 	 */
 	insecure_memzero(passbuf, MAXPASSLEN);
 	insecure_memzero(confpassbuf, MAXPASSLEN);
+
+	resetsigs(savedsa);
 
 	/* Success! */
 	return (0);

--- a/main.c
+++ b/main.c
@@ -55,6 +55,7 @@ main(int argc, char *argv[])
 {
 	FILE * infile;
 	FILE * outfile;
+	int devtty = 1;
 	int dec = 0;
 	size_t maxmem = 0;
 	double maxmemfrac = 0.5;
@@ -98,6 +99,9 @@ main(int argc, char *argv[])
 		GETOPT_OPT("-v"):
 			verbose = 1;
 			break;
+		GETOPT_OPT("-P"):
+			devtty = 0;
+			break;
 		GETOPT_MISSING_ARG:
 			warn0("Missing argument to %s\n", ch);
 			/* FALLTHROUGH */
@@ -134,7 +138,7 @@ main(int argc, char *argv[])
 
 	/* Prompt for a password. */
 	if (readpass(&passwd, "Please enter passphrase",
-	    dec ? NULL : "Please confirm passphrase", 1))
+	    (dec || !devtty) ? NULL : "Please confirm passphrase", devtty))
 		exit(1);
 
 	/* Encrypt or decrypt. */

--- a/scrypt.1
+++ b/scrypt.1
@@ -55,6 +55,12 @@ and writes the result to
 if specified, or the standard output otherwise.
 The user will be prompted to enter the passphrase used at
 encryption time to generate the derived encryption key.
+.Pp
+.Nm
+reads passphrases from its controlling terminal, or failing that,
+from stdin.  Prompts are only printed if this means that
+.Nm
+is reading passphrases from some terminal.
 .Sh OPTIONS
 .Bl -tag -width "-m maxmemfrac"
 .It Fl M Ar maxmem

--- a/scrypt.1
+++ b/scrypt.1
@@ -33,6 +33,7 @@
 .Op Fl M Ar maxmem
 .Op Fl m Ar maxmemfrac
 .Op Fl t Ar maxtime
+.Op Fl P
 .Ar infile
 .Op Ar outfile
 .Nm
@@ -61,6 +62,8 @@ reads passphrases from its controlling terminal, or failing that,
 from stdin.  Prompts are only printed if this means that
 .Nm
 is reading passphrases from some terminal.
+(But, see
+.Sm Fl P Li .)
 .Sh OPTIONS
 .Bl -tag -width "-m maxmemfrac"
 .It Fl M Ar maxmem
@@ -75,6 +78,9 @@ of the available RAM to compute the derived encryption key.
 Use at most
 .Ar maxtime
 seconds of CPU time to compute the derived encryption key.
+.It Fl P
+Always read passphrase from stdin, and do so only once even
+when encrypting.
 .It Fl -version
 Print version of scrypt, and exit.
 .El


### PR DESCRIPTION
This makes it easier to use the command-line scrypt utility in scripts etc.  This is particularly useful because the scrypt utility contains some parameter choosing and storing logic which is not exposed in a cooked way elsewhere.

Signed-off-by: Ian Jackson <ijackson@chiark.greenend.org.uk>