### PR TITLE
Add -P option to usage

### DIFF
--- a/main.c
+++ b/main.c
@@ -44,7 +44,7 @@ usage(void)
 
 	fprintf(stderr,
 	    "usage: scrypt {enc | dec} [-M maxmem] [-m maxmemfrac]"
-	    " [-t maxtime] [-v] infile\n"
+	    " [-t maxtime] [-v] [-P] infile\n"
 	    "              [outfile]\n"
 	    "       scrypt --version\n");
 	exit(1);


### PR DESCRIPTION
I was taking a look through the scrypt source, and found the new -P option missing from the usage statement in the code. Figured I'd throw a quick pull request together to fix it.