### PR TITLE
README.md: fix scrypt header filename: s/enc/scrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Using scrypt as a KDF
 To use scrypt as a
 [key derivation function](https://en.wikipedia.org/wiki/Key_derivation_function)
 (KDF), take a
-look at the `lib/crypto/crypto_enc.h` header, which provides:
+look at the `lib/crypto/crypto_scrypt.h` header, which provides:
 
 ```
 /**


### PR DESCRIPTION
This was fixed in
https://github.com/Tarsnap/website/commit/4b72c6ad575f55f1e822c651cae4a235f46c56e3
but I forgot to update the README after fixing the website.

Addresses #43.