### PR TITLE
Remove unused header file

### DIFF
--- a/lib/crypto/crypto_scrypt_smix.c
+++ b/lib/crypto/crypto_scrypt_smix.c
@@ -29,7 +29,6 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "sha256.h"
 #include "sysendian.h"
 
 #include "crypto_scrypt_smix.h"


### PR DESCRIPTION
A minor change, but it may help people using this code outside of the library (one less local change to track if they don't have an sha256.h).