### PR TITLE
"echo -n" is not portable; use printf

### DIFF
--- a/release-tools/mktarball.sh
+++ b/release-tools/mktarball.sh
@@ -19,7 +19,7 @@ sed -e "s/@DATE@/$RELEASEDATE/" < scrypt.1 > ${DESTDIR}/scrypt.1
 
 # Generate autotools files
 ( cd ${DESTDIR}
-echo -n ${VERSION} > scrypt-version
+printf ${VERSION} > scrypt-version
 autoreconf -i
 rm .autom4te.cfg Makefile.am aclocal.m4 configure.ac scrypt-version )
 


### PR DESCRIPTION
    It is not possible to use echo portably across all POSIX systems unless
    both -n (as the first argument) and escape sequences are omitted.

http://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html