### PR TITLE
tests: add valgrind if $USE_VALGRIND is defined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: C
 sudo: required
 dist: trusty
+script: make && make test USE_VALGRIND=1
 env:
   global:
     - secure: "Th4Z1fktV+H5Sgf7SvHCg5oUgRuLnfI+E4NzzfeJXOTKTlMUuf0OZCKRW7jQkj5ISwX/ovOl7tMLGc47CPiebWWCgdwe6sh8APTDZh++0unWLERmuEtiwmc3RjdwlZvgE+hmR+CzYRu/EjDoN3lKSUXUZ9vh2CANcpak0PMNht/A7nT5jzZ7NIN7o53VEpAK+8z0A6rn9p9ETZy/IqSidqVU41es6gg1pnHxbhiNunX33IalKeOPAjtLCm/H/a/vs8ibh2KXYCodbcEB6SFtF4l8sm70OI/bTdXCE3almFrSd28gzNgrwfXKgFB5tdkl4FgDNYlU2bfdrEjkDHfjN/B8B2zbeJh+8DyRP5jdF2hhEpOSyT/Y68vbowMDHQaBNDey0WoEFp6bfBSjRouu8GM/J0qrx9MrQCU39BUYbicT/zHMh4VsIrcfFGrWFL9nfFb9ml+Dd1AOxOfr0fZkaS0ouXvG3wB7X+ing2qGVLeZ+wqDaoNYcaat6TQxH6FtdSzm68G5YE48f7GoUSKcNe+APXXEwUdthrUL+gM5JQG41HXBCfWbAlvuSi9f6lfCoM5uIR2Hz39m/B4fqllwhmIPuRfGORiNGxxcgT7/x9WYurbcqtXWAbwbNGUQwl8WhFU7EkadhmJiv0Wu8xmT4ZEP/lg6kEQttf4JoKIxTkU="
@@ -9,6 +10,8 @@ env:
     - COVERITY_SCAN_NOTIFICATION_EMAIL="cperciva@tarsnap.com"
     - COVERITY_SCAN_BUILD_COMMAND="make all clean"
 before_install:
+  - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi'
+  - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y valgrind; fi'
   - autoreconf -i
   - ./configure
   - curl -s "https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh" | bash || true

--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ A small test suite can be run with:
 
     make test
 
+Memory-testing normal operations with valgrind (takes approximately 4 times as
+long as no valgrind tests) can be enabled with:
+
+    make test USE_VALGRIND=1
+
+Memory-testing all tests with valgrind (requires over 1 GB memory, and takes
+approximately 4 times as long as `USE_VALGRIND=1`) can be enabled with:
+
+    make test USE_VALGRIND=2
+
 
 Mailing list
 ------------

--- a/test/shared_test_functions.sh
+++ b/test/shared_test_functions.sh
@@ -1,13 +1,82 @@
 #!/bin/sh
 
-## notify_success_or_fail (retval):
-# Print "PASSED!" or "FAILED!" based on $retval.
+# A non-zero value unlikely to be used as an exit code by the programs being
+# tested.
+valgrind_exit_code=108
+
+## check_optional_valgrind ():
+# Return a $USE_VALGRIND variable defined; if it was previously defined and
+# was greater than 0, then check that valgrind is available in the $PATH.
+check_optional_valgrind() {
+	if [ -z "$USE_VALGRIND" ]; then
+		USE_VALGRIND=0
+	fi
+	if [ "$USE_VALGRIND" -gt 0 ]; then
+		# Look for valgrind in $PATH.
+		if ! command -v valgrind >/dev/null 2>&1; then
+			echo "valgrind not detected"
+			exit 1
+		fi
+	fi
+	echo "$USE_VALGRIND"
+}
+
+## setup_valgrind_cmd (val_logfilename, valgrind_disable_number=0):
+# Return a valid valgrind command if $USE_VALGRIND is higher than
+# $valgrind_disable_number; otherwise, returns an empty string.
+setup_valgrind_cmd() {
+	val_logfilename=$1
+	# The user-specified $USE_VALGRIND number must be higher than
+	# $valgrind_disable_number; this allows us to specify certain tests as
+	# being "normal memory usage" or "lots of memory required; most people
+	# won't want to run valgrind on this".
+	valgrind_disable_number=${2:-0}
+
+	# Set up the valgrind command (if requested).  Using --error-exitcode
+	# means that if there is a serious problem (such that scrypt calls
+	# exit(1)) *and* a memory leak, the test suite reports an exit value
+	# of $valgrind_exit_code.  However, if there is a serious problem but
+	# no memory leak, we still receive a non-zero exit code.  The most
+	# important thing is that we only receive an exit code of 0 if both
+	# the program and valgrind are happy.
+	if [ "$USE_VALGRIND" -gt "$valgrind_disable_number" ]; then
+		valgrind_cmd="valgrind \
+			--log-file=$val_logfilename \
+			--leak-check=full --show-leak-kinds=all \
+			--errors-for-leak-kinds=all \
+			--error-exitcode=$valgrind_exit_code "
+	else
+		valgrind_cmd=""
+	fi
+
+	# Return command to calling function.
+	echo "$valgrind_cmd"
+}
+
+## notify_success_or_fail (retval, (val_retval, val_logfilename)*):
+# Print "PASSED!" or "FAILED!" based on $retval.  In a failure condition,
+# examine pairs of optional arguments; if $val_retval*k is the constant
+# $valgrind_exit_code, output $val_logfilename*k to stdout, for k>=0.
 notify_success_or_fail() {
 	retval=$1
+	shift
 
 	if [ "$retval" -eq 0 ]; then
 		echo "PASSED!"
 	else
 		echo "FAILED!"
+
+		# If valgrind discovered a problem, print it.  This is
+		# primarily aimed at automation in travis-CI, since we don't
+		# have access to the log files.
+		while [ ! "$#" -eq 0 ]; do
+			val_retval=$1
+			val_logfilename=$2
+			if [ "$val_retval" -eq "$valgrind_exit_code" ]; then
+				cat $val_logfilename
+			fi
+			shift
+			shift
+		done
 	fi
 }

--- a/test/shared_test_functions.sh
+++ b/test/shared_test_functions.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+## notify_success_or_fail (retval):
+# Print "PASSED!" or "FAILED!" based on $retval.
+notify_success_or_fail() {
+	retval=$1
+
+	if [ "$retval" -eq 0 ]; then
+		echo "PASSED!"
+	else
+		echo "FAILED!"
+	fi
+}

--- a/test/test_scrypt.sh
+++ b/test/test_scrypt.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# File locations (allowing flexible out-of-tree builds)
+# File locations (allowing flexible out-of-tree builds).
 scrypt_binary=$1
 test_scrypt_binary=$2
 reference_txt=$3
@@ -13,7 +13,9 @@ encrypted_file="attempt.enc"
 decrypted_file="attempt.txt"
 decrypted_reference_file="attempt_reference.txt"
 
-# Check for parameters
+################################ Setup variables from the command-line
+
+# Check for required arguments.
 if [ -z $scrypt_binary ] || [ -z $test_scrypt_binary ] || \
     [ -z $reference_txt ] || [ -z $reference_enc ]; then
 	printf "Error: Scrypt binary, test binary, good file, or good "
@@ -30,9 +32,13 @@ if [ ! -f $scrypt_binary ] || [ ! -f $test_scrypt_binary ] || \
 	exit 1
 fi
 
-# Test functions
+################################ Test functions
+
 test_known_values() {
-	printf "Test 01: Generate known test values... "
+	basename="01-generate-known-test-values"
+	printf "Running test: $basename... "
+
+	# Run actual test command.
 	$test_scrypt_binary > $known_values
 
 	# The generated values should match the known good values.
@@ -48,7 +54,10 @@ test_known_values() {
 }
 
 test_encrypt_file() {
-	printf "Test 02: Encrypt a file... "
+	basename="02-encrypt-a-file"
+	printf "Running test: $basename... "
+
+	# Run actual test command.
 	echo $password | $scrypt_binary enc -P $reference_txt \
 		$encrypted_file
 
@@ -68,7 +77,10 @@ test_encrypt_file() {
 }
 
 test_decrypt_file() {
-	printf "Test 03: Decrypt a file... "
+	basename="03-decrypt-a-file"
+	printf "Running test: $basename... "
+
+	# Run actual test command.
 	echo $password | $scrypt_binary dec -P $encrypted_file \
 		$decrypted_file
 
@@ -86,7 +98,10 @@ test_decrypt_file() {
 }
 
 test_decrypt_reference_file() {
-	printf "Test 04: Decrypt a reference encrypted file... "
+	basename="04-decrypt-a-reference-encrypted-file"
+	printf "Running test: $basename... "
+
+	# Run actual test command.
 	echo $password | $scrypt_binary dec -P $reference_enc \
 		$decrypted_reference_file
 
@@ -102,12 +117,14 @@ test_decrypt_reference_file() {
 	return "$retval"
 }
 
-# Run tests
+################################ Run tests
+
+# Run tests.
 test_known_values &&			\
 	test_encrypt_file &&		\
 	test_decrypt_file &&		\
 	test_decrypt_reference_file	\
 
-# Return value to Makefile
+# Return value to Makefile.
 exit $?
 


### PR DESCRIPTION
In particular, most tests are enable if $USE_VALGRIND > 0, but
01-generate-known-test-values uses a lot of memory so it is only run through
valgrind if $USE_VALGRIND > 1.