### PR TITLE
build: add -D_POSIX_C_SOURCE=200809L

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,8 @@ AM_CPPFLAGS=		-I$(srcdir)/libcperciva/alg		\
 			-I$(srcdir)/lib/crypto			\
 			-I$(srcdir)/lib/scryptenc 		\
 			-I$(srcdir)/lib/util			\
-			-DCPUSUPPORT_CONFIG_FILE=\"cpusupport-config.h\"
+			-DCPUSUPPORT_CONFIG_FILE=\"cpusupport-config.h\" \
+			-D_POSIX_C_SOURCE=200809L
 scrypt_LDADD=		libcperciva_aesni.a libscrypt_sse2.a
 scrypt_man_MANS=	scrypt.1
 


### PR DESCRIPTION
Without this, clang-3.8 with -std=c99 on Ubuntu 16.04 fails to find SSIZE_MAX
in limits.h.  This is because SSIZE_MAX is in .../bits/posix1_lim.h, and
/usr/include/limits.h contains:

    #ifdef  __USE_POSIX
    /* POSIX adds things to <limits.h>.  */
    # include <bits/posix1_lim.h>
    #endif

and in "\_\_STRICT_ANSI\_\_" mode (implied by -std=c99, amongst other things),
__USE_POSIX is only defined if we've defined _POSIX_C_SOURCE or _XOPEN_SOURCE.