### PR TITLE
build: don't install test_scrypt

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,5 @@
-bin_PROGRAMS=	scrypt tests/test_scrypt
+bin_PROGRAMS=	scrypt
+noinst_PROGRAMS=	tests/test_scrypt
 dist_man_MANS=$(scrypt_man_MANS)
 
 scrypt_SOURCES=		main.c					\


### PR DESCRIPTION
This was previously not installed.  One could argue that the ability to run the standard test strings ("", "password", "pleaseletmein") could be useful even with a binary-only package, but even in that case I think we'd want to dump test_scrypt into somewhere under share/ rather than bin/.