### PR TITLE
Explicit cast to (uint64_t) from getrlimit()

### DIFF
--- a/lib/util/memlimit.c
+++ b/lib/util/memlimit.c
@@ -163,7 +163,7 @@ memlimit_rlimit(size_t * memlimit)
 		return (1);
 	if ((rl.rlim_cur != RLIM_INFINITY) &&
 	    ((uint64_t)rl.rlim_cur < memrlimit))
-		memrlimit = rl.rlim_cur;
+		memrlimit = (uint64_t)rl.rlim_cur;
 #endif
 
 	/* ... RLIMIT_DATA... */
@@ -171,7 +171,7 @@ memlimit_rlimit(size_t * memlimit)
 		return (1);
 	if ((rl.rlim_cur != RLIM_INFINITY) &&
 	    ((uint64_t)rl.rlim_cur < memrlimit))
-		memrlimit = rl.rlim_cur;
+		memrlimit = (uint64_t)rl.rlim_cur;
 
 	/* ... and RLIMIT_RSS. */
 #ifdef RLIMIT_RSS
@@ -179,7 +179,7 @@ memlimit_rlimit(size_t * memlimit)
 		return (1);
 	if ((rl.rlim_cur != RLIM_INFINITY) &&
 	    ((uint64_t)rl.rlim_cur < memrlimit))
-		memrlimit = rl.rlim_cur;
+		memrlimit = (uint64_t)rl.rlim_cur;
 #endif
 
 	/* Return the value, but clamp to SIZE_MAX if necessary. */


### PR DESCRIPTION
- This assumes that the amount of available memory available to the process, or the max size of the data segment, or the resident set, will not exceed 18 exibytes (2^64).

- This also assumes that FreeBSD (which uses a signed int for rlim_t, in violation of the POSIX standard) will not return a negative value.