### PR TITLE
Remove unnecessary header

### DIFF
--- a/main.c
+++ b/main.c
@@ -25,7 +25,6 @@
  */
 #include "scrypt_platform.h"
 
-#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
`<inttypes.h>` was only required for

```
uintmax_t maxmem_uintmax;
```

but now that we're reading -M with humansize_parse() instead of strtoumax(), we're using a uint64_t, which is covered by `<stdint.h>`.
