### PR TITLE
Initialize memlimit and opps even when not checked

### DIFF
--- a/lib/scryptenc/scryptenc.c
+++ b/lib/scryptenc/scryptenc.c
@@ -175,6 +175,10 @@ checkparams(size_t maxmem, double maxmemfrac, double maxtime,
 			return (9);
 		if ((opslimit / N) / (r * p) < 4)
 			return (10);
+	} else {
+		/* We have no limit. */
+		memlimit = 0;
+		opps = 0;
 	}
 
 	if (verbose)


### PR DESCRIPTION
We print these variables if --verbose is given, so we can't merely leave them uninitialized if -f is specified.