### PR TITLE
Explicit casts to (size_t)

### DIFF
--- a/lib/crypto/crypto_scrypt.c
+++ b/lib/crypto/crypto_scrypt.c
@@ -115,7 +115,7 @@ _crypto_scrypt(const uint8_t * passwd, size_t passwdlen,
 #endif
 #endif
 #if defined(MAP_ANON) && defined(HAVE_MMAP)
-	if ((V0 = mmap(NULL, 128 * r * N, PROT_READ | PROT_WRITE,
+	if ((V0 = mmap(NULL, (size_t)(128 * r * N), PROT_READ | PROT_WRITE,
 #ifdef MAP_NOCORE
 	    MAP_ANON | MAP_PRIVATE | MAP_NOCORE,
 #else
@@ -140,7 +140,7 @@ _crypto_scrypt(const uint8_t * passwd, size_t passwdlen,
 
 	/* Free memory. */
 #if defined(MAP_ANON) && defined(HAVE_MMAP)
-	if (munmap(V0, 128 * r * N))
+	if (munmap(V0, (size_t)(128 * r * N)))
 		goto err2;
 #else
 	free(V0);


### PR DESCRIPTION
As with 5f1aedd59a608719d33c4d119be78aa70d736cf6, we already ensured that
    N <= SIZE_MAX / 128 / r
so we know that (128 * r * N) fits into (size_t).

[N is (uint64_t), so this issue only arose on a 32-bit system with
-D_GNU_SOURCE added to CFLAGS, as that implicitly sets MAP_ANON.]