### PR TITLE
Fix division-by-zero bug in scrypt decryption

### DIFF
--- a/lib/scryptenc/scryptenc.c
+++ b/lib/scryptenc/scryptenc.c
@@ -157,6 +157,8 @@ checkparams(size_t maxmem, double maxmemfrac, double maxtime,
 		return (7);
 	if ((uint64_t)(r) * (uint64_t)(p) >= 0x40000000)
 		return (7);
+	if ((r == 0) || (p == 0))
+		return (7);
 
 	/* Are we forcing decryption, regardless of resource limits? */
 	if (!force) {
@@ -173,7 +175,7 @@ checkparams(size_t maxmem, double maxmemfrac, double maxtime,
 		N = (uint64_t)(1) << logN;
 		if ((memlimit / N) / r < 128)
 			return (9);
-		if ((opslimit / N) / (r * p) < 4)
+		if (((opslimit / N) / r) / p < 4)
 			return (10);
 	} else {
 		/* We have no limit. */


### PR DESCRIPTION
If either of the parameters "r" or "p" were zero, or their product
is zero (modulo 2^32, thanks to the behaviour of uint32_t) when
entering checkparams, we would get a division-by-zero abort prior
to this commit.

Reported by:	Eyal Itkin
Security:	A corrupt key file can cause tarsnap to crash instead
		of exiting with the correct error message.
Bug Bounty:	$100