### PR TITLE
Add support for Intel SHA256 instructions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -82,6 +82,7 @@ EXTRA_DIST = \
 	lib/README						\
 	README.md						\
 	lib/crypto/crypto_scrypt-ref.c				\
+	libcperciva/cpusupport/Build/cpusupport-X86-SHANI.c	\
 	libcperciva/cpusupport/Build/cpusupport-X86-AESNI.c	\
 	libcperciva/cpusupport/Build/cpusupport-X86-CPUID.c	\
 	libcperciva/cpusupport/Build/cpusupport-X86-SSE2.c	\

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,6 +4,7 @@ dist_man_MANS=$(scrypt_man_MANS)
 
 scrypt_SOURCES=		main.c					\
 			libcperciva/alg/sha256.c		\
+			libcperciva/cpusupport/cpusupport_x86_shani.c \
 			libcperciva/cpusupport/cpusupport_x86_aesni.c \
 			libcperciva/cpusupport/cpusupport_x86_sse2.c \
 			libcperciva/crypto/crypto_aes.c		\
@@ -33,6 +34,7 @@ scrypt_SOURCES=		main.c					\
 			libcperciva/crypto/crypto_aes_aesni.h	\
 			libcperciva/crypto/crypto_aesctr.h	\
 			libcperciva/crypto/crypto_entropy.h	\
+			libcperciva/crypto/crypto_sha256_shani.h	\
 			libcperciva/util/asprintf.h		\
 			libcperciva/util/entropy.h		\
 			libcperciva/util/getopt.h		\
@@ -54,7 +56,7 @@ AM_CPPFLAGS=		-I$(srcdir)/libcperciva/alg		\
 			-DCPUSUPPORT_CONFIG_FILE=\"cpusupport-config.h\" \
 			-D_POSIX_C_SOURCE=200809L
 
-scrypt_LDADD=		libcperciva_aesni.a libscrypt_sse2.a
+scrypt_LDADD=		libcperciva_shani.a libcperciva_aesni.a libscrypt_sse2.a
 scrypt_man_MANS=	scrypt.1
 
 cpusupport-config.h:
@@ -62,7 +64,11 @@ cpusupport-config.h:
 BUILT_SOURCES=	cpusupport-config.h
 CLEANFILES=	cpusupport-config.h cpusupport-config.h.tmp
 
-noinst_LIBRARIES=	libcperciva_aesni.a
+noinst_LIBRARIES=	libcperciva_shani.a
+libcperciva_shani_a_SOURCES=	libcperciva/crypto/crypto_sha256_shani.c
+libcperciva_shani_a_CFLAGS=`. ./cpusupport-config.h; echo $${CFLAGS_X86_SHANI}`
+
+noinst_LIBRARIES+=	libcperciva_aesni.a
 libcperciva_aesni_a_SOURCES=	libcperciva/crypto/crypto_aes_aesni.c
 libcperciva_aesni_a_CFLAGS=`. ./cpusupport-config.h; echo $${CFLAGS_X86_AESNI}`
 

--- a/libcperciva/cpusupport/Build/cpusupport-X86-SHANI.c
+++ b/libcperciva/cpusupport/Build/cpusupport-X86-SHANI.c
@@ -1,0 +1,14 @@
+#include <immintrin.h>
+
+static char a[16];
+
+int
+main(void)
+{
+	__m128i x, y;
+
+	x = _mm_loadu_si128((__m128i *)a);
+	y = _mm_sha256msg1_epu32(x, x);
+	_mm_storeu_si128((__m128i *)a, y);
+	return (a[0]);
+}

--- a/libcperciva/cpusupport/Build/cpusupport.sh
+++ b/libcperciva/cpusupport/Build/cpusupport.sh
@@ -46,3 +46,4 @@ feature() {
 feature X86 CPUID ""
 feature X86 SSE2 "" "-msse2" "-msse2 -Wno-cast-align"
 feature X86 AESNI "" "-maes" "-maes -Wno-cast-align" "-maes -Wno-missing-prototypes -Wno-cast-qual"
+feature X86 SHANI "" "-msse4.1 -msha" "-msse4.1 -msha -Wno-cast-align" "-maes -Wno-missing-prototypes -Wno-cast-qual"

--- a/libcperciva/cpusupport/cpusupport.h
+++ b/libcperciva/cpusupport/cpusupport.h
@@ -100,6 +100,7 @@
  * corresponding run-time detection code (cpusupport_arch_feature.c) must be
  * compiled and linked in.
  */
+CPUSUPPORT_FEATURE(x86, shani, X86_SHANI);
 CPUSUPPORT_FEATURE(x86, aesni, X86_AESNI);
 CPUSUPPORT_FEATURE(x86, sse2, X86_SSE2);
 

--- a/libcperciva/cpusupport/cpusupport_x86_shani.c
+++ b/libcperciva/cpusupport/cpusupport_x86_shani.c
@@ -1,0 +1,30 @@
+#include "cpusupport.h"
+
+#ifdef CPUSUPPORT_X86_CPUID
+#include <cpuid.h>
+
+#define CPUID_SHANI_BIT (1 << 29)
+#endif
+
+CPUSUPPORT_FEATURE_DECL(x86, shani)
+{
+#ifdef CPUSUPPORT_X86_CPUID
+	unsigned int eax, ebx, ecx, edx;
+
+	/* Check if CPUID supports the level we need. */
+	if (!__get_cpuid(0, &eax, &ebx, &ecx, &edx))
+		goto unsupported;
+	if (eax < 7)
+		goto unsupported;
+
+	/* Ask about CPU features. */
+	if (!__get_cpuid(1, &eax, &ebx, &ecx, &edx))
+		goto unsupported;
+
+	/* Return the relevant feature bit. */
+	return ((ebx & CPUID_SHANI_BIT) ? 1 : 0);
+
+unsupported:
+#endif
+	return (0);
+}

--- a/libcperciva/crypto/crypto_sha256_shani.c
+++ b/libcperciva/crypto/crypto_sha256_shani.c
@@ -1,0 +1,217 @@
+#include "cpusupport.h"
+#ifdef CPUSUPPORT_X86_SHANI
+
+#include <stdint.h>
+#include <immintrin.h>
+
+#include "insecure_memzero.h"
+#include "warnp.h"
+
+#include "crypto_sha256_shani.h"
+
+/**
+ * crypto_sha_hash_blocks_shani(state, block):
+ * Hash one block using Intel SHA hardware acceleration. This implementation
+ * uses x86 SHANI instructions, and should only be used if CPUSUPPORT_X86_SHANI
+ * is defined and cpusupport_x86_shani() returns nonzero.
+ */
+void crypto_sha256_shani(uint32_t * state, const uint8_t * data)
+{
+	__m128i STATE0, STATE1;
+	__m128i MSG, TMP;
+	__m128i MSG0, MSG1, MSG2, MSG3;
+	__m128i ABEF_SAVE, CDGH_SAVE;
+	const __m128i MASK = _mm_set_epi64x(0x0c0d0e0f08090a0b, 0x0405060700010203);
+
+	/* Load initial values */
+	TMP = _mm_loadu_si128((const __m128i*) &state[0]);
+	STATE1 = _mm_loadu_si128((const __m128i*) &state[4]);
+
+
+	TMP = _mm_shuffle_epi32(TMP, 0xB1);		  /* CDAB */
+	STATE1 = _mm_shuffle_epi32(STATE1, 0x1B);	/* EFGH */
+	STATE0 = _mm_alignr_epi8(TMP, STATE1, 8);	/* ABEF */
+	STATE1 = _mm_blend_epi16(STATE1, TMP, 0xF0); /* CDGH */
+
+	/* This function hashes multiple blocks. Set length to 64 */
+	/* but keep while loop to hash multiple blocks. The       */
+	/* project can safely remove the while loop if unwanted.  */
+	size_t length = 64;
+
+	while (length >= 64)
+	{
+		/* Save current state */
+		ABEF_SAVE = STATE0;
+		CDGH_SAVE = STATE1;
+
+		/* Rounds 0-3 */
+		MSG = _mm_loadu_si128((const __m128i*) (data+0));
+		MSG0 = _mm_shuffle_epi8(MSG, MASK);
+		MSG = _mm_add_epi32(MSG0, _mm_set_epi64x(0xE9B5DBA5B5C0FBCF, 0x71374491428A2F98));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+
+		/* Rounds 4-7 */
+		MSG1 = _mm_loadu_si128((const __m128i*) (data+16));
+		MSG1 = _mm_shuffle_epi8(MSG1, MASK);
+		MSG = _mm_add_epi32(MSG1, _mm_set_epi64x(0xAB1C5ED5923F82A4, 0x59F111F13956C25B));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+		MSG0 = _mm_sha256msg1_epu32(MSG0, MSG1);
+
+		/* Rounds 8-11 */
+		MSG2 = _mm_loadu_si128((const __m128i*) (data+32));
+		MSG2 = _mm_shuffle_epi8(MSG2, MASK);
+		MSG = _mm_add_epi32(MSG2, _mm_set_epi64x(0x550C7DC3243185BE, 0x12835B01D807AA98));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+		MSG1 = _mm_sha256msg1_epu32(MSG1, MSG2);
+
+		/* Rounds 12-15 */
+		MSG3 = _mm_loadu_si128((const __m128i*) (data+48));
+		MSG3 = _mm_shuffle_epi8(MSG3, MASK);
+		MSG = _mm_add_epi32(MSG3, _mm_set_epi64x(0xC19BF1749BDC06A7, 0x80DEB1FE72BE5D74));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		TMP = _mm_alignr_epi8(MSG3, MSG2, 4);
+		MSG0 = _mm_add_epi32(MSG0, TMP);
+		MSG0 = _mm_sha256msg2_epu32(MSG0, MSG3);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+		MSG2 = _mm_sha256msg1_epu32(MSG2, MSG3);
+
+		/* Rounds 16-19 */
+		MSG = _mm_add_epi32(MSG0, _mm_set_epi64x(0x240CA1CC0FC19DC6, 0xEFBE4786E49B69C1));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		TMP = _mm_alignr_epi8(MSG0, MSG3, 4);
+		MSG1 = _mm_add_epi32(MSG1, TMP);
+		MSG1 = _mm_sha256msg2_epu32(MSG1, MSG0);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+		MSG3 = _mm_sha256msg1_epu32(MSG3, MSG0);
+
+		/* Rounds 20-23 */
+		MSG = _mm_add_epi32(MSG1, _mm_set_epi64x(0x76F988DA5CB0A9DC, 0x4A7484AA2DE92C6F));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		TMP = _mm_alignr_epi8(MSG1, MSG0, 4);
+		MSG2 = _mm_add_epi32(MSG2, TMP);
+		MSG2 = _mm_sha256msg2_epu32(MSG2, MSG1);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+		MSG0 = _mm_sha256msg1_epu32(MSG0, MSG1);
+
+		/* Rounds 24-27 */
+		MSG = _mm_add_epi32(MSG2, _mm_set_epi64x(0xBF597FC7B00327C8, 0xA831C66D983E5152));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		TMP = _mm_alignr_epi8(MSG2, MSG1, 4);
+		MSG3 = _mm_add_epi32(MSG3, TMP);
+		MSG3 = _mm_sha256msg2_epu32(MSG3, MSG2);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+		MSG1 = _mm_sha256msg1_epu32(MSG1, MSG2);
+
+		/* Rounds 28-31 */
+		MSG = _mm_add_epi32(MSG3, _mm_set_epi64x(0x1429296706CA6351,  0xD5A79147C6E00BF3));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		TMP = _mm_alignr_epi8(MSG3, MSG2, 4);
+		MSG0 = _mm_add_epi32(MSG0, TMP);
+		MSG0 = _mm_sha256msg2_epu32(MSG0, MSG3);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+		MSG2 = _mm_sha256msg1_epu32(MSG2, MSG3);
+
+		/* Rounds 32-35 */
+		MSG = _mm_add_epi32(MSG0, _mm_set_epi64x(0x53380D134D2C6DFC, 0x2E1B213827B70A85));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		TMP = _mm_alignr_epi8(MSG0, MSG3, 4);
+		MSG1 = _mm_add_epi32(MSG1, TMP);
+		MSG1 = _mm_sha256msg2_epu32(MSG1, MSG0);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+		MSG3 = _mm_sha256msg1_epu32(MSG3, MSG0);
+
+		/* Rounds 36-39 */
+		MSG = _mm_add_epi32(MSG1, _mm_set_epi64x(0x92722C8581C2C92E, 0x766A0ABB650A7354));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		TMP = _mm_alignr_epi8(MSG1, MSG0, 4);
+		MSG2 = _mm_add_epi32(MSG2, TMP);
+		MSG2 = _mm_sha256msg2_epu32(MSG2, MSG1);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+		MSG0 = _mm_sha256msg1_epu32(MSG0, MSG1);
+
+		/* Rounds 40-43 */
+		MSG = _mm_add_epi32(MSG2, _mm_set_epi64x(0xC76C51A3C24B8B70, 0xA81A664BA2BFE8A1));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		TMP = _mm_alignr_epi8(MSG2, MSG1, 4);
+		MSG3 = _mm_add_epi32(MSG3, TMP);
+		MSG3 = _mm_sha256msg2_epu32(MSG3, MSG2);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+		MSG1 = _mm_sha256msg1_epu32(MSG1, MSG2);
+
+		/* Rounds 44-47 */
+		MSG = _mm_add_epi32(MSG3, _mm_set_epi64x(0x106AA070F40E3585, 0xD6990624D192E819));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		TMP = _mm_alignr_epi8(MSG3, MSG2, 4);
+		MSG0 = _mm_add_epi32(MSG0, TMP);
+		MSG0 = _mm_sha256msg2_epu32(MSG0, MSG3);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+		MSG2 = _mm_sha256msg1_epu32(MSG2, MSG3);
+
+		/* Rounds 48-51 */
+		MSG = _mm_add_epi32(MSG0, _mm_set_epi64x(0x34B0BCB52748774C, 0x1E376C0819A4C116));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		TMP = _mm_alignr_epi8(MSG0, MSG3, 4);
+		MSG1 = _mm_add_epi32(MSG1, TMP);
+		MSG1 = _mm_sha256msg2_epu32(MSG1, MSG0);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+		MSG3 = _mm_sha256msg1_epu32(MSG3, MSG0);
+
+		/* Rounds 52-55 */
+		MSG = _mm_add_epi32(MSG1, _mm_set_epi64x(0x682E6FF35B9CCA4F, 0x4ED8AA4A391C0CB3));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		TMP = _mm_alignr_epi8(MSG1, MSG0, 4);
+		MSG2 = _mm_add_epi32(MSG2, TMP);
+		MSG2 = _mm_sha256msg2_epu32(MSG2, MSG1);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+
+		/* Rounds 56-59 */
+		MSG = _mm_add_epi32(MSG2, _mm_set_epi64x(0x8CC7020884C87814, 0x78A5636F748F82EE));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		TMP = _mm_alignr_epi8(MSG2, MSG1, 4);
+		MSG3 = _mm_add_epi32(MSG3, TMP);
+		MSG3 = _mm_sha256msg2_epu32(MSG3, MSG2);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+
+		/* Rounds 60-63 */
+		MSG = _mm_add_epi32(MSG3, _mm_set_epi64x(0xC67178F2BEF9A3F7, 0xA4506CEB90BEFFFA));
+		STATE1 = _mm_sha256rnds2_epu32(STATE1, STATE0, MSG);
+		MSG = _mm_shuffle_epi32(MSG, 0x0E);
+		STATE0 = _mm_sha256rnds2_epu32(STATE0, STATE1, MSG);
+
+		/* Combine state  */
+		STATE0 = _mm_add_epi32(STATE0, ABEF_SAVE);
+		STATE1 = _mm_add_epi32(STATE1, CDGH_SAVE);
+
+		data += 64;
+		length -= 64;
+	}
+
+	TMP = _mm_shuffle_epi32(STATE0, 0x1B);	   /* FEBA */
+	STATE1 = _mm_shuffle_epi32(STATE1, 0xB1);	/* DCHG */
+	STATE0 = _mm_blend_epi16(TMP, STATE1, 0xF0); /* DCBA */
+	STATE1 = _mm_alignr_epi8(STATE1, TMP, 8);	/* ABEF */
+
+	/* Save state */
+	_mm_storeu_si128((__m128i*) &state[0], STATE0);
+	_mm_storeu_si128((__m128i*) &state[4], STATE1);
+}
+
+#endif

--- a/libcperciva/crypto/crypto_sha256_shani.h
+++ b/libcperciva/crypto/crypto_sha256_shani.h
@@ -1,0 +1,14 @@
+#ifndef _CRYPTO_SHA_SHANI_H_
+#define _CRYPTO_SHA_SHANI_H_
+
+#include <stdint.h>
+
+/**
+ * crypto_sha_hash_blocks_shani(state, block):
+ * Hash one block using Intel SHA hardware acceleration. This implementation
+ * uses x86 SHANI instructions, and should only be used if CPUSUPPORT_X86_SHANI
+ * is defined and cpusupport_x86_shani() returns nonzero.
+ */
+void crypto_sha256_shani(uint32_t * state, const uint8_t * data);
+
+#endif


### PR DESCRIPTION
This is a partial cut-in of SHA256 support on Intel x86 platforms. I did not see how to glue it into `sha256.c` so others will need to finish the integration (if there is interest in the code).

This implementation will run about 3.8 cycles per byte.

The SHA256 implementation came from [SHA-Intrinsics](https://github.com/noloader/SHA-Intrinsics). All the code is public domain. If scrypt is interested in the code, then similar code is available for ARM and POWER8.

I'm not sure what is going on with the Clang failure on the integral constant. I've been using the code for about a years and a half under Clang, GCC, ICC and MSVC, and it has never caused a problem. A question is open at [Problems with hexadecimal constant, _mm_set_epi64x and sign conversion](https://lists.llvm.org/pipermail/cfe-users/2018-March/001284.html).