### PR TITLE
Strict semicolon usage

### DIFF
--- a/libcperciva/alg/sha256.c
+++ b/libcperciva/alg/sha256.c
@@ -152,7 +152,7 @@ useshani(void)
 #define RND(a, b, c, d, e, f, g, h, k)			\
 	h += S1(e) + Ch(e, f, g) + k;			\
 	d += h;						\
-	h += S0(a) + Maj(a, b, c);
+	h += S0(a) + Maj(a, b, c)
 
 /* Adjusted round function for rotating state */
 #define RNDr(S, W, i, ii)			\


### PR DESCRIPTION
When RND() ended with a semicolon, RNDr() also ended with one, so lines like
    RNDr(S, W, 0, i);
resulted in two adjacent semicolons.

Granted, C99 allows for null statements, so it's not an /error/.  But
clang-8 isn't fond of it, and I see no reason to keep the extra
semicolon.