### PR TITLE
Travis-CI: switch to bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: C
-sudo: false
-dist: trusty
+# Ubuntu xenial 16.04 comes with valgrind-3.11, which can't handle the
+# RDRAND instructions and aborts with "Illegal instruction".  This is not a
+# problem with Ubuntu bionic 18.04, which has valgrind-3.13.
+dist: bionic
 addons:
   apt:
     packages:


### PR DESCRIPTION
This distro comes with valgrind which can understand the RDRAND instruction.