### PR TITLE
Increase maximum value of the p cmdline parameter

### DIFF
--- a/main.c
+++ b/main.c
@@ -282,7 +282,7 @@ main(int argc, char * argv[])
 			}
 			break;
 		GETOPT_OPTARG("-p"):
-			GETOPT_PARSENUM_WITHIN_UNSIGNED(&params.p, 1, 32);
+			GETOPT_PARSENUM_WITHIN_UNSIGNED(&params.p, 1, 2048);
 			break;
 		GETOPT_OPTARG("--passphrase"):
 			if (passphrase_entry != PASSPHRASE_UNSET) {


### PR DESCRIPTION
The upper limit of the value of the `-p` cmdline parameter is 32, which is relatively low. Currently, hashing with logN=20, r=8 and p=32 takes around 90s on my slow CPU (Intel i3-7020U).

This is in contrast to the `--logN` parameter, which can be set up to 40, which corresponds to 1TB of RAM. Additionally, the program will automatically pick high values of `p` when given high values of the `-t` (maxtime) parameter.

So allow specifying higher values of the `p` parameter in cmdline.