### PR TITLE
Reject zero r or p in reference scrypt

### DIFF
--- a/FORMAT
+++ b/FORMAT
@@ -5,8 +5,8 @@ offset	length
 0	6	"scrypt"
 6	1	scrypt data file version number (== 0)
 7	1	log2(N) (must be between 1 and 63 inclusive)
-8	4	r (big-endian integer; must satisfy r * p < 2^30)
-12	4	p (big-endian integer; must satisfy r * p < 2^30)
+8	4	r (big-endian integer; must satisfy 0 < r * p < 2^30)
+12	4	p (big-endian integer; must satisfy 0 < r * p < 2^30)
 16	32	salt
 48	16	first 16 bytes of SHA256(bytes 0 .. 47)
 64	32	HMAC-SHA256(bytes 0 .. 63)

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ https://en.wikipedia.org/wiki/Key_derivation_function) (KDF) with
  * scrypt_kdf(passwd, passwdlen, salt, saltlen, N, r, p, buf, buflen):
  * Compute scrypt(passwd[0 .. passwdlen - 1], salt[0 .. saltlen - 1], N, r,
  * p, buflen) and write the result into buf.  The parameters r, p, and buflen
- * must satisfy r * p < 2^30 and buflen <= (2^32 - 1) * 32.  The parameter N
- * must be a power of 2 greater than 1.
+ * must satisfy 0 < r * p < 2^30 and buflen <= (2^32 - 1) * 32.  The parameter
+ * N must be a power of 2 greater than 1.
  *
  * Return 0 on success; or -1 on error.
  */

--- a/lib/crypto/crypto_scrypt-ref.c
+++ b/lib/crypto/crypto_scrypt-ref.c
@@ -205,8 +205,8 @@ smix(uint8_t * B, size_t r, uint64_t N, uint8_t * V, uint8_t * XY)
  * crypto_scrypt(passwd, passwdlen, salt, saltlen, N, r, p, buf, buflen):
  * Compute scrypt(passwd[0 .. passwdlen - 1], salt[0 .. saltlen - 1], N, r,
  * p, buflen) and write the result into buf.  The parameters r, p, and buflen
- * must satisfy r * p < 2^30 and buflen <= (2^32 - 1) * 32.  The parameter N
- * must be a power of 2.
+ * must satisfy 0 < r * p < 2^30 and buflen <= (2^32 - 1) * 32.  The parameter
+ * N must be a power of 2.
  *
  * Return 0 on success; or -1 on error.
  */
@@ -222,6 +222,10 @@ crypto_scrypt(const uint8_t * passwd, size_t passwdlen,
 	uint32_t i;
 
 	/* Sanity-check parameters. */
+	if ((r == 0) || (p == 0)) {
+		errno = EINVAL;
+		goto err0;
+	}
 #if SIZE_MAX > UINT32_MAX
 	if (buflen > (((uint64_t)(1) << 32) - 1) * 32) {
 		errno = EFBIG;

--- a/libscrypt-kdf/scrypt-kdf.h
+++ b/libscrypt-kdf/scrypt-kdf.h
@@ -44,8 +44,8 @@ extern "C" {
  * scrypt_kdf(passwd, passwdlen, salt, saltlen, N, r, p, buf, buflen):
  * Compute scrypt(passwd[0 .. passwdlen - 1], salt[0 .. saltlen - 1], N, r,
  * p, buflen) and write the result into buf.  The parameters r, p, and buflen
- * must satisfy r * p < 2^30 and buflen <= (2^32 - 1) * 32.  The parameter N
- * must be a power of 2 greater than 1.
+ * must satisfy 0 < r * p < 2^30 and buflen <= (2^32 - 1) * 32.  The parameter
+ * N must be a power of 2 greater than 1.
  *
  * Return 0 on success; or -1 on error.
  */


### PR DESCRIPTION
## Summary
- reject `r == 0` or `p == 0` in `crypto_scrypt()` with `EINVAL`
- document the lower bound as `0 < r * p < 2^30` in `FORMAT`, `README.md`, `scrypt-kdf.h`, and the reference implementation comment

## Notes
This follows up on 686a628f995d86685d87045c80fba0ffce318c71 as requested in #405.

## Tests
- `git diff --check`

Split out from #405.
