### PR TITLE
Add reference scrypt parameter validation test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,6 @@
 bin_PROGRAMS=	scrypt
 noinst_PROGRAMS=							\
+	tests/invalid-params/test_scrypt_ref_params			\
 	tests/valgrind/potential-memleaks				\
 	tests/verify-strings/test_scrypt
 dist_man_MANS=$(scrypt_man_MANS)
@@ -287,6 +288,24 @@ tests_verify_strings_test_scrypt_LDADD=					\
 	libscrypt_sse2.la						\
 	${LDADD_POSIX}
 
+# Binary to test parameter validation in the reference crypto_scrypt().
+tests_invalid_params_test_scrypt_ref_params_SOURCES=			\
+	tests/invalid-params/test_scrypt_ref_params.c			\
+	lib/crypto/crypto_scrypt-ref.c					\
+	libcperciva/alg/sha256.c					\
+	libcperciva/alg/sha256.h					\
+	libcperciva/util/insecure_memzero.c				\
+	libcperciva/util/insecure_memzero.h				\
+	libcperciva/util/warnp.c					\
+	libcperciva/util/warnp.h
+
+tests_invalid_params_test_scrypt_ref_params_LDADD=			\
+	libcperciva_arm_sha256.la					\
+	libcperciva_cpusupport_detect.la				\
+	libcperciva_shani.la						\
+	libscrypt_sse2.la						\
+	${LDADD_POSIX}
+
 # Eliminate false positives while memory-checking for the test framework.
 tests_valgrind_potential_memleaks_SOURCES= tests/valgrind/potential-memleaks.c
 
@@ -294,4 +313,5 @@ tests_valgrind_potential_memleaks_SOURCES= tests/valgrind/potential-memleaks.c
 # we can't only build "scrypt tests/verify-strings/test_scrypt" because that
 # won't build the BUILT_SOURCES.
 test: all
+	$(top_builddir)/tests/invalid-params/test_scrypt_ref_params
 	$(top_srcdir)/tests/test_scrypt.sh .

--- a/tests/invalid-params/test_scrypt_ref_params.c
+++ b/tests/invalid-params/test_scrypt_ref_params.c
@@ -1,0 +1,40 @@
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "crypto_scrypt.h"
+
+static int
+check_invalid_params(uint64_t N, uint32_t r, uint32_t p)
+{
+	uint8_t kbuf[16];
+
+	errno = 0;
+	if (crypto_scrypt((const uint8_t *)"passwd", 6,
+	    (const uint8_t *)"salt", 4, N, r, p, kbuf, sizeof(kbuf)) != -1) {
+		printf("crypto_scrypt(%llu, %u, %u) succeeded\n",
+		    (unsigned long long)N, (unsigned int)r, (unsigned int)p);
+		return (1);
+	}
+	if (errno != EINVAL) {
+		printf("crypto_scrypt(%llu, %u, %u) failed with errno %d\n",
+		    (unsigned long long)N, (unsigned int)r, (unsigned int)p,
+		    errno);
+		return (1);
+	}
+
+	return (0);
+}
+
+int
+main(void)
+{
+	int failures = 0;
+
+	failures += check_invalid_params(16, 0, 1);
+	failures += check_invalid_params(16, 1, 0);
+	failures += check_invalid_params(1, 1, 1);
+
+	return (failures ? 1 : 0);
+}


### PR DESCRIPTION
## Summary
- add a dedicated invalid-parameter test for the reference `crypto_scrypt()` implementation
- cover zero `r`, zero `p`, and `N == 1`
- place the test under `tests/invalid-params/` rather than `tests/verify-strings/`

## Dependency
This is intentionally opened as a draft because the test is expected to pass after the validation fixes in #406 and #407 are applied.

## Tests
- `git diff --check`

Split out from #405.
