### PR TITLE
Zero scrypt scratch buffers before freeing

### DIFF
--- a/lib-platform/crypto/crypto_scrypt.c
+++ b/lib-platform/crypto/crypto_scrypt.c
@@ -44,6 +44,7 @@
 #include "crypto_scrypt_smix_sse2.h"
 
 #include "crypto_scrypt.h"
+#include "insecure_memzero.h"
 
 static void (* smix_func)(uint8_t *, size_t, uint64_t, void *, void *) = NULL;
 
@@ -144,12 +145,15 @@ crypto_scrypt_internal(const uint8_t * passwd, size_t passwdlen,
 	PBKDF2_SHA256(passwd, passwdlen, B, p * 128 * r, 1, buf, buflen);
 
 	/* Free memory. */
+	insecure_memzero(V, (size_t)(128 * r * N));
 #if defined(MAP_ANON) && defined(HAVE_MMAP)
 	if (munmap(V0, (size_t)(128 * r * N)))
 		goto err2;
 #else
 	free(V0);
 #endif
+	insecure_memzero(XY, 256 * r + 64);
+	insecure_memzero(B, 128 * r * p);
 	free(XY0);
 	free(B0);
 
@@ -157,8 +161,10 @@ crypto_scrypt_internal(const uint8_t * passwd, size_t passwdlen,
 	return (0);
 
 err2:
+	insecure_memzero(XY, 256 * r + 64);
 	free(XY0);
 err1:
+	insecure_memzero(B, 128 * r * p);
 	free(B0);
 err0:
 	/* Failure! */

--- a/lib/crypto/crypto_scrypt-ref.c
+++ b/lib/crypto/crypto_scrypt-ref.c
@@ -35,6 +35,7 @@
 #include "sysendian.h"
 
 #include "crypto_scrypt.h"
+#include "insecure_memzero.h"
 
 static void blkcpy(uint8_t *, uint8_t *, size_t);
 static void blkxor(uint8_t *, uint8_t *, size_t);
@@ -267,6 +268,9 @@ crypto_scrypt(const uint8_t * passwd, size_t passwdlen,
 	PBKDF2_SHA256(passwd, passwdlen, B, p * 128 * r, 1, buf, buflen);
 
 	/* Free memory. */
+	insecure_memzero(V, 128 * r * N);
+	insecure_memzero(XY, 256 * r);
+	insecure_memzero(B, 128 * r * p);
 	free(V);
 	free(XY);
 	free(B);
@@ -275,8 +279,10 @@ crypto_scrypt(const uint8_t * passwd, size_t passwdlen,
 	return (0);
 
 err2:
+	insecure_memzero(XY, 256 * r);
 	free(XY);
 err1:
+	insecure_memzero(B, 128 * r * p);
 	free(B);
 err0:
 	/* Failure! */


### PR DESCRIPTION
## Summary

Zero the scratch buffers used by `crypto_scrypt()` before releasing them:

- wipe `B`, `XY`, and `V` in the reference implementation
- wipe `B`, `XY`, and `V` in the platform implementation
- cover both success and allocation-error cleanup paths

This uses the existing `insecure_memzero()` helper already linked by the project.

Refs Tarsnap/tarsnap#703.

## Validation

- `git diff --check HEAD~1 HEAD`
- Reviewed the optimized `smix` storage contract and zeroed the full `256 * r + 64` `XY` region in the platform implementation.

I could not run `autoreconf && ./configure && make test` locally because this Windows environment does not have the C/autotools toolchain installed and WSL is not installed.