### PR TITLE
readpass_file: reject a passphrase file with a stray carriage return

### DIFF
--- a/libcperciva/util/readpass_file.c
+++ b/libcperciva/util/readpass_file.c
@@ -22,6 +22,7 @@ readpass_file(char ** passwd, const char * filename)
 {
 	FILE * f;
 	char passbuf[MAXPASSLEN];
+	size_t len;
 
 	/* Open the file. */
 	if ((f = fopen(filename, "r")) == NULL) {
@@ -52,8 +53,28 @@ readpass_file(char ** passwd, const char * filename)
 		goto err1;
 	}
 
-	/* Truncate at any newline character. */
-	passbuf[strcspn(passbuf, "\r\n")] = '\0';
+	/*
+	 * Strip a trailing "\n" or "\r\n".  fgets() stops after a "\n", so
+	 * if the file contains one then it is the last character we read.
+	 */
+	len = strlen(passbuf);
+	if ((len > 0) && (passbuf[len - 1] == '\n')) {
+		passbuf[--len] = '\0';
+		if ((len > 0) && (passbuf[len - 1] == '\r'))
+			passbuf[--len] = '\0';
+	}
+
+	/*
+	 * Any "\r" or "\n" left is not a line ending we strip.  We could cut
+	 * the passphrase short there, or keep the character as part of the
+	 * passphrase, but both change the passphrase which an existing file
+	 * yields, and neither is safe to pick silently.  Refuse the file.
+	 */
+	if (strcspn(passbuf, "\r\n") != len) {
+		warn0("passphrase in %s contains a carriage return or newline",
+		    filename);
+		goto err1;
+	}
 
 	/* Copy the password out. */
 	if ((*passwd = strdup(passbuf)) == NULL) {

--- a/tests/08-passphrase-file.sh
+++ b/tests/08-passphrase-file.sh
@@ -10,6 +10,7 @@ decrypted_reference_file="${s_basename}-attempt_reference.txt"
 decrypted_badpass_file="${s_basename}-decrypt-badpass.txt"
 decrypted_badpass_log="${s_basename}-decrypt-badpass.log"
 decrypted_no_file_log="${s_basename}-decrypt-no-file.log"
+decrypted_no_file="${s_basename}-decrypt-no-file.txt"
 cr_passphrase_file="${s_basename}-passphrase-cr.txt"
 decrypted_cr_file="${s_basename}-decrypt-cr.txt"
 decrypted_cr_log="${s_basename}-decrypt-cr.log"
@@ -37,7 +38,7 @@ scenario_cmd() {
 	setup_check "scrypt dec file none"
 	${c_valgrind_cmd} "${bindir}/scrypt"				\
 	    dec --passphrase file:THIS_FILE_DOES_NOT_EXIST		\
-	    "${encrypted_reference_file}" "${decrypted_reference_file}"	\
+	    "${encrypted_reference_file}" "${decrypted_no_file}"		\
 	    2> "${decrypted_no_file_log}"
 	expected_exitcode 1 $? > "${c_exitfile}"
 
@@ -49,7 +50,7 @@ scenario_cmd() {
 
 	# We should not have created a file.
 	setup_check "scrypt dec file none no file"
-	test -e "${decrypted_badpass_file}"
+	test -e "${decrypted_no_file}"
 	expected_exitcode 1 $? > "${c_exitfile}"
 
 	# Attempt to decrypt the reference file with an incorrect passphrase.
@@ -58,7 +59,7 @@ scenario_cmd() {
 	echo "bad-pass" > "${bad_passphrase_file}"
 	${c_valgrind_cmd} "${bindir}/scrypt"				\
 	    dec --passphrase file:"${bad_passphrase_file}"		\
-	    "${encrypted_reference_file}" "${decrypted_reference_file}"	\
+	    "${encrypted_reference_file}" "${decrypted_badpass_file}"		\
 	    2> "${decrypted_badpass_log}"
 	expected_exitcode 1 $? > "${c_exitfile}"
 

--- a/tests/08-passphrase-file.sh
+++ b/tests/08-passphrase-file.sh
@@ -10,6 +10,11 @@ decrypted_reference_file="${s_basename}-attempt_reference.txt"
 decrypted_badpass_file="${s_basename}-decrypt-badpass.txt"
 decrypted_badpass_log="${s_basename}-decrypt-badpass.log"
 decrypted_no_file_log="${s_basename}-decrypt-no-file.log"
+cr_passphrase_file="${s_basename}-passphrase-cr.txt"
+decrypted_cr_file="${s_basename}-decrypt-cr.txt"
+decrypted_cr_log="${s_basename}-decrypt-cr.log"
+crlf_passphrase_file="${s_basename}-passphrase-crlf.txt"
+decrypted_crlf_file="${s_basename}-decrypt-crlf.txt"
 
 scenario_cmd() {
 	# Create the passphrase file.
@@ -66,4 +71,38 @@ scenario_cmd() {
 	setup_check "scrypt dec file bad no file"
 	test -e "${decrypted_badpass_file}"
 	expected_exitcode 1 $? > "${c_exitfile}"
+
+	# A passphrase file containing a carriage return which is not part of
+	# a trailing CRLF must be rejected.  The passphrase used here begins
+	# with the correct passphrase, so accepting it would decrypt the file
+	# with a passphrase which is not the one the file contains.
+	setup_check "scrypt dec file stray CR"
+	printf '%s\rextra\n' "${password}" > "${cr_passphrase_file}"
+	${c_valgrind_cmd} "${bindir}/scrypt"				\
+	    dec --passphrase file:"${cr_passphrase_file}"		\
+	    "${encrypted_reference_file}" "${decrypted_cr_file}"	\
+	    2> "${decrypted_cr_log}"
+	expected_exitcode 1 $? > "${c_exitfile}"
+
+	# We should have received an error message.
+	setup_check "scrypt dec file stray CR error"
+	grep -q "carriage return or newline" "${decrypted_cr_log}"
+	echo "$?" > "${c_exitfile}"
+
+	# We should not have created a file.
+	setup_check "scrypt dec file stray CR no file"
+	test -e "${decrypted_cr_file}"
+	expected_exitcode 1 $? > "${c_exitfile}"
+
+	# A passphrase file with CRLF line endings must still work.
+	setup_check "scrypt dec file CRLF"
+	printf '%s\r\n' "${password}" > "${crlf_passphrase_file}"
+	${c_valgrind_cmd} "${bindir}/scrypt"				\
+	    dec --passphrase file:"${crlf_passphrase_file}"		\
+	    "${encrypted_reference_file}" "${decrypted_crlf_file}"
+	echo $? > "${c_exitfile}"
+
+	setup_check "scrypt dec file CRLF output against reference"
+	cmp -s "${decrypted_crlf_file}" "${reference_file}"
+	echo $? > "${c_exitfile}"
 }


### PR DESCRIPTION
> **Disclosure, per this repository's `AGENTS.md`:** I am an LLM (Claude), submitting on behalf of the account owner. I am available to discuss this change and to revise it in response to review feedback.

Fixes #431.

`readpass_file()` ends with

```c
	/* Truncate at any newline character. */
	passbuf[strcspn(passbuf, "\r\n")] = '\0';
```

`fgets()` stops after a `\n`, and the `fgetc(f) != EOF` check above rejects
anything following it, so a `\n` in the buffer is always the last character.
A `\r` is not: `fgets()` reads past it, so a `\r` anywhere in the line reaches
`strcspn()` and silently cuts the passphrase off there.

`--passphrase file:pw` with `pw` containing `hunter2\rextra` therefore uses
`hunter2`.  It round-trips, because encryption truncates the same way, so
nothing shows until the passphrase is supplied by another route.  The header
in `libcperciva/util/readpass.h` already says a file like that should be
rejected:

> Print an error and fail if the file is 2048 characters or more, or if it
> contains any newline \n or \r\n characters other than at the end of the
> file.

### The change

Strip a trailing `\n` or `\r\n` explicitly, then reject the file if any `\r`
or `\n` is left.  I did not make the leftover character part of the
passphrase: both that and the current truncation change the passphrase an
existing file yields, and neither is safe to choose on the user's behalf
without telling them.  No documentation change — this makes the code match
what `readpass.h` already describes.

Files whose only newline is a `\n` or a trailing `\r\n` are unaffected, so
ordinary Unix and Windows passphrase files keep working.

### Test

`tests/08-passphrase-file.sh` gains four checks rather than a new test file:

* a passphrase file containing `hunter2\rextra` must be rejected, with the
  error message, and must not create an output file.  The passphrase begins
  with the correct one, so before this change that decryption *succeeds* and
  the check fails — it is a real regression test, not a restatement.
* a passphrase file with CRLF line endings must still decrypt the reference
  file correctly.

### Note

This is `libcperciva` code, so it also lives in tarsnap and kivaloo; I have
only touched the copy in this repository.
